### PR TITLE
Allow empty dns

### DIFF
--- a/lib/caravan/cluster/dns_strategy.ex
+++ b/lib/caravan/cluster/dns_strategy.ex
@@ -87,7 +87,7 @@ defmodule Caravan.Cluster.DnsStrategy do
 
   def handle_info(:poll, %State{meta: {pi, q, node_sname, [], dns}} = state) do
     q
-    |> dns.get_nodes()
+    |> dns.get_nodes([])
     |> create_node_names(node_sname)
     |> remove_self()
     |> connect(state)

--- a/lib/caravan/cluster/dns_strategy.ex
+++ b/lib/caravan/cluster/dns_strategy.ex
@@ -85,6 +85,17 @@ defmodule Caravan.Cluster.DnsStrategy do
     {:ok, state}
   end
 
+  def handle_info(:poll, %State{meta: {pi, q, node_sname, [], dns}} = state) do
+    q
+    |> dns.get_nodes()
+    |> create_node_names(node_sname)
+    |> remove_self()
+    |> connect(state)
+
+    Process.send_after(self(), :poll, pi)
+    {:noreply, state}
+  end
+
   def handle_info(:poll, %State{meta: {pi, q, node_sname, nameservers, dns}} = state) do
     q
     |> dns.get_nodes(nameservers: nameservers)

--- a/lib/caravan/cluster/dns_strategy.ex
+++ b/lib/caravan/cluster/dns_strategy.ex
@@ -38,7 +38,7 @@ defmodule Caravan.Cluster.DnsStrategy do
           #forms the base of the node name. App name is a good one.
           node_sname: "profile-service",
           #If you need to override the default DNS server. Must be an ip port
-          #combo like below. Defaults to {"127.0.0.1", "53"}
+          #combo like below. Defaults to [] (dns are inherited from system)
           nameservers: [{"10.0.183.34", "8700"}],
           #The poll interval for the Consul service in milliseconds. Defaults to 5s
           poll_interval: 5_000
@@ -115,7 +115,7 @@ defmodule Caravan.Cluster.DnsStrategy do
   end
 
   defp process_dns_servers([]) do
-    [{{127, 0, 0, 1}, 53}]
+    []
   end
 
   # Conform :ip datatype has a tuple of binaries for ip and port, so handle it

--- a/test/caravan/cluster/dns_strategy_test.exs
+++ b/test/caravan/cluster/dns_strategy_test.exs
@@ -14,7 +14,7 @@ defmodule Caravan.Cluster.DnsStrategyTest do
       node_sname: "connectnodetest"
     ]
 
-    {:ok, pid} = start_cluster_strategy(create_config(config))
+    {:ok, _pid} = start_cluster_strategy(create_config(config))
     :timer.sleep(100)
   end
 
@@ -31,7 +31,7 @@ defmodule Caravan.Cluster.DnsStrategyTest do
   end
 
   defp create_config(opts) do
-    config = [
+    [
       topology: :caravan_test,
       connect: Keyword.get(opts, :connect, {:net_kernel, :connect, []}),
       disconnect: {:net_kernel, :disconnect, []},


### PR DESCRIPTION
Hey,

Thank you for your amazing library.

This PR aims to allow caravan to use system DNS (inherited from /etc/resolv.conf) by modifying the behavior on nameservers, if we detect an empty array, we don't send any opts to inet_res.lookup.

This is very useful in our situation (we are running in docker containers where DNS aren't directly accessible from containers).

@uberbrodt  Thanks by advance for your review :)